### PR TITLE
#bugfix#生成cache文件的路径少了分隔符。

### DIFF
--- a/library/src/main/java/com/seek/biscuit/ImageCompressor.java
+++ b/library/src/main/java/com/seek/biscuit/ImageCompressor.java
@@ -183,7 +183,7 @@ public class ImageCompressor implements Compressor {
 
     private String getCacheFileName() {
         StringBuilder cacheBuilder = new StringBuilder();
-        cacheBuilder.append(targetDir);
+        cacheBuilder.append(targetDir).append(File.separator);
         if (useOriginalName && !TextUtils.isEmpty(sourcePath.name)) {
             cacheBuilder.append(sourcePath.name);
         } else {


### PR DESCRIPTION
少了分隔符，导致清除缓存API失效。